### PR TITLE
Fix the linux build

### DIFF
--- a/libpmd/model_def.inc
+++ b/libpmd/model_def.inc
@@ -143,7 +143,7 @@ struct Model: Rangecoder_SH1x<ProcMode> {
       rc_Quit(); 
     }
 */
-    yield(this,0);
+    this->yield(this,0);
   }
 
   #include "ppmd_byte.inc"


### PR DESCRIPTION
The build on linux fails with the following error:

```
g++  -c -o vendor/ppmd_sh.o -Ivendor/ppmd_sh/ -Ivendor/ppmd_sh/libpmd vendor/ppmd_sh.cpp
In file included from vendor/ppmd_sh/libpmd/libpmd.inc:4,
                 from vendor/ppmd_sh.cpp:23:
vendor/ppmd_sh/libpmd/model_def.inc: In instantiation of ‘void Model<ProcMode>::do_process() [with int ProcMode = 1]’:
vendor/ppmd_sh/libpmd/libpmd.inc:70:26:   required from here
vendor/ppmd_sh/libpmd/model_def.inc:146:10: error: ‘yield’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
  146 |     yield(this,0);
      |     ~~~~~^~~~~~~~
vendor/ppmd_sh/libpmd/model_def.inc:146:10: note: declarations in dependent base ‘Coroutine’ are not found by unqualified lookup
vendor/ppmd_sh/libpmd/model_def.inc:146:10: note: use ‘this->yield’ instead
vendor/ppmd_sh/libpmd/model_def.inc: In instantiation of ‘void Model<ProcMode>::do_process() [with int ProcMode = 0]’:
vendor/ppmd_sh/libpmd/libpmd.inc:70:44:   required from here
vendor/ppmd_sh/libpmd/model_def.inc:146:10: error: ‘yield’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
vendor/ppmd_sh/libpmd/model_def.inc:146:10: note: declarations in dependent base ‘Coroutine’ are not found by unqualified lookup
vendor/ppmd_sh/libpmd/model_def.inc:146:10: note: use ‘this->yield’ instead
```

The pull request fixes it.